### PR TITLE
refactor: make page un-scrollable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Hello } from "./components/Hello/Hello";
 
 const FullPageContainer = styled.article`
+  position: fixed;
   display: flex;
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
On desktop units it doesn't really matter. On native devices it removes
the ugly scrollable interface. I.e. it becomes un-scrollable